### PR TITLE
Fix json.Number parsing of numeric json values

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"github.com/99designs/gqlgen/graphql"
 	"reflect"
+	"bytes"
 )
 
 type GraphqlRawParamsCollection []*graphql.RawParams

--- a/handler.go
+++ b/handler.go
@@ -19,17 +19,24 @@ func (c GraphqlRawParamsCollection) Len() int {
 
 // UnmarshalJSON could unmarshal slice or single query
 func (c *GraphqlRawParamsCollection) UnmarshalJSON(b []byte) error {
-	err := json.Unmarshal(b, (*[]*graphql.RawParams)(c))
-	if err == nil {
+	r := bytes.NewReader(b)
+
+	d := json.NewDecoder(r)
+	d.UseNumber()
+
+	if err := d.Decode((*[]*graphql.RawParams)(c)); err == nil {
 		return nil
+	}
+
+	if _, err := r.Seek(0, 0); err != nil {
+		return err
 	}
 
 	var n graphql.RawParams
-	err = json.Unmarshal(b, &n)
-	if err == nil {
-		*c = []*graphql.RawParams{&n}
+	if err := d.Decode(&n); err != nil {
 		return nil
 	}
 
+	*c = []*graphql.RawParams{&n}
 	return nil
 }


### PR DESCRIPTION
This fixes the invalid behaviour that numerical json values are interpreted as `float64`'s, even though `jsonDecode` uses `.UseNumber()`.

Since `json.Unmarshal()` uses it's own decoder without `.UseNumber()`, this has to be added manually.

Btw.: Great project, i hope you can merge this ASAP, because this currently breaks query variables with numbers.